### PR TITLE
[WIP] Remove associated OTR keys when account is removed

### DIFF
--- a/chrome/content/helpers.js
+++ b/chrome/content/helpers.js
@@ -32,6 +32,10 @@ var helpers = {
     return OS.File.exists(filename);
   },
 
+  removeFile: function(filename) {
+    return OS.File.remove(filename);
+  },
+
   readTextFile: function(filename) {
     let decoder = new TextDecoder();
     return OS.File.read(filename).then(function(array) {

--- a/chrome/content/libc.js
+++ b/chrome/content/libc.js
@@ -62,6 +62,16 @@ var libC = {
     ctypes.void_t.ptr,
     ctypes.size_t
   ),
+  memcpy: libc.declare(
+    "memcpy", libcAbi, ctypes.void_t.ptr,
+    ctypes.void_t.ptr,
+    ctypes.void_t.ptr,
+    ctypes.size_t
+  ),
+  malloc: libc.declare(
+    "malloc", libcAbi, ctypes.void_t.ptr,
+    ctypes.size_t
+  ),
   free: libc.declare(
     "free", libcAbi, ctypes.void_t,
     ctypes.void_t.ptr

--- a/chrome/content/ui.js
+++ b/chrome/content/ui.js
@@ -204,6 +204,7 @@ var ui = {
       // Disabled until #76 is resolved.
       // Services.obs.addObserver(ui, "contact-added", false);
       Services.obs.addObserver(ui, "account-added", false);
+      Services.obs.addObserver(ui, "account-removed", false);
       Services.obs.addObserver(ui, "conversation-loaded", false);
       Services.obs.addObserver(ui, "conversation-closed", false);
       Services.obs.addObserver(ui, "prpl-quit", false);
@@ -528,6 +529,16 @@ var ui = {
     });
   },
 
+  onAccountRemoved: function(acc, prplId) {
+    let account = acc.normalizedName;
+    let protocol = Services.core.getProtocolById(prplId).normalizedName;
+    try {
+      otr.forgetPrivateKey(account, protocol);
+    } catch(err) {
+      Cu.reportError(err);
+    }
+  },
+
   contactWrapper: function(contact) {
     let wrapper = {
       account: contact.preferredBuddy.preferredAccountBuddy.account.normalizedName,
@@ -595,6 +606,9 @@ var ui = {
     case "account-added":
       ui.onAccountCreated(aObject);
       break;
+    case "account-removed":
+      ui.onAccountRemoved(aObject, aMsg);
+      break;
     case "contact-added":
       ui.onContactAdded(aObject);
       break;
@@ -626,6 +640,7 @@ var ui = {
     Services.obs.removeObserver(otr, "new-ui-conversation");
     // Services.obs.removeObserver(ui, "contact-added");
     Services.obs.removeObserver(ui, "account-added");
+    Services.obs.removeObserver(ui, "account-removed");
     Services.obs.removeObserver(ui, "conversation-loaded");
     Services.obs.removeObserver(ui, "conversation-closed");
     Services.obs.removeObserver(ui, "prpl-quit");


### PR DESCRIPTION
We need to use memcpy instead of assigning the pointer directly https://github.com/arlolra/ctypes-otr/pull/95/files#diff-0ae302860237c1727af8cba50ff6e1c6R272. Currently the app crashes because of "double free" (perhaps).



